### PR TITLE
Win cleanup (#1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ Tools/CmdLine/IccSpecSepToTiff/TiffImg.cpp
 Tools/CmdLine/IccSpecSepToTiff/TiffImg.h
 Tools/CmdLine/IccTiffDump/TiffImg.cpp
 Tools/CmdLine/IccTiffDump/TiffImg.h
+
+*.sdf
+*.vcxproj.user
+IccProfLib/Win32

--- a/IccProfLib/IccProfLib_v14.vcxproj
+++ b/IccProfLib/IccProfLib_v14.vcxproj
@@ -176,7 +176,7 @@
       <AdditionalIncludeDirectories>$(EIGEN);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeaderOutputFile>$(Platform)\$(Configuration)/IccProfLib.pch</PrecompiledHeaderOutputFile>
       <AssemblerListingLocation>$(Platform)\$(Configuration)/</AssemblerListingLocation>
@@ -185,6 +185,7 @@
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DisableSpecificWarnings>4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -229,7 +230,7 @@
       <AdditionalIncludeDirectories>$(EIGEN);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <PrecompiledHeaderOutputFile>$(Platform)\$(Configuration)/IccProfLib.pch</PrecompiledHeaderOutputFile>
       <AssemblerListingLocation>$(Platform)\$(Configuration)/</AssemblerListingLocation>
       <ObjectFileName>$(Platform)\$(Configuration)/</ObjectFileName>

--- a/IccProfLib/IccTagMPE.h
+++ b/IccProfLib/IccTagMPE.h
@@ -156,7 +156,11 @@ public:
   virtual CIccMultiProcessElement *NewCopy() const = 0;
 
   virtual icElemTypeSignature GetType() const = 0;
-  virtual const icChar *GetClassName() const = 0;
+  //virtual const char *GetClassName() const  = 0;
+  //when this function is declared as pure virtual, instances of all derived classes
+  //cannot be instantiated though this function is overwritten in those derived classes with exactly same signature;
+  //couldn't find the source of the problem. workaround is implemented by removal of pure virtuality (next line).
+  virtual const char *GetClassName() const { return "CIccMultiProcessElement"; }
 
   virtual icUInt16Number NumInputChannels() const { return m_nInputChannels; }
   virtual icUInt16Number NumOutputChannels() const { return m_nOutputChannels; }

--- a/IccProfLib/icProfileHeader.h
+++ b/IccProfLib/icProfileHeader.h
@@ -162,7 +162,7 @@ authorization from SunSoft Inc.
 /* Header file guard bands */
 #ifndef icPROFILEHEADER_H
 #define icPROFILEHEADER_H
-
+#include "IccProfLibConf.h"
 #if !defined(ICCCONFIG_h)
     #error Include icProfLibConf.h before this file
 #endif
@@ -1433,7 +1433,7 @@ typedef struct {
     icUInt16Number      funcType;       /* Function Type                */
                                         /* 0 = gamma only               */
     icUInt16Number      pad;            /* Padding for byte alignment   */
-    icS15Fixed16Number  gamma;          /* x°gamma                      */
+    icS15Fixed16Number*  gamma;          /* x°gamma                      */
                                         /* up to 7 values Y,a,b,c,d,e,f */
 } icParametricCurve;
 


### PR DESCRIPTION
# Introduction

This is a pull request of the X-Rite fork back into RefIccMAX that makes the IccProfLib_v14 project compile and link on Win32 with VS2015 when included in the Prism solution.

## Summary of changes:
* added windows files to the git ignore

* changed the IccProfLib_v14.vcxproj from Mt/Mt_d to Md/Md_d to match Prism

* fixed "cannot instantiate abstract class" compile error by giving a definition to the base class GetClassName()

* included the file as indicated by the compiler error

* fixed a compile error by changing the type in the struct to long* because it's being accessed with the [] operator

## Squashed commit log

* compiling on windows

* updated git ignore file with vcxproj and sdf and win32 folder in icc max

* remove nulls

* using the one in the origin

* fixing release mode

* IcProfileHeader.h cleanup

* iccTagMPE.h cleanup

* IccMpeBasic.h is restored to macOS-cleanup branch state

* IccMpeBasic.h cleanup

* IccMpeBasic.h final cleanup

* addresing reviewer's comments

* fixing typo in comment