### PR TITLE
Fix undeclared identifier nanf error

### DIFF
--- a/IccXML/IccLibXML/IccUtilXml.cpp
+++ b/IccXML/IccLibXML/IccUtilXml.cpp
@@ -73,6 +73,7 @@
 #endif
 #endif
 #include <cstring> /* C strings strcpy, memcpy ... */
+#include <math.h>  /* nanf */
 
 
 


### PR DESCRIPTION
I got undefined identifier nanf with Xcode. It is defined in math.h according to
https://en.cppreference.com/w/c/numeric/math/nan
This fixes that.
